### PR TITLE
drv/mr_timer: set irq priority lower than uart and radio

### DIFF
--- a/drv/mr_radio/mr_radio_default.c
+++ b/drv/mr_radio/mr_radio_default.c
@@ -26,11 +26,8 @@
 #define NRF_RADIO NRF_RADIO_NS
 #endif
 
-#if defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+/// Radio interrupt priority, set lower than the UART priority (0) and timer priority (1)
 #define RADIO_INTERRUPT_PRIORITY 2
-#else
-#define RADIO_INTERRUPT_PRIORITY 1
-#endif
 
 #define RADIO_TIFS 0U  ///< Inter frame spacing in us. zero means IFS is enforced by software, not the hardware
 

--- a/drv/mr_timer_hf/mr_timer_hf.c
+++ b/drv/mr_timer_hf/mr_timer_hf.c
@@ -19,6 +19,10 @@
 
 //=========================== define ===========================================
 
+/// Timer interrupt priority, must be lower than the UART priority (0)
+/// This is used to ensure that the timer interrupt cannot preempt the UART interrupt
+/// which requires very tight timing to ensure no data is lost
+#define TIMER_IRQ_PRIORITY (1U)
 #define TIMER_MAX_CHANNELS (6U)
 
 typedef struct {
@@ -116,6 +120,7 @@ void mr_timer_hf_init(timer_hf_t timer) {
     _devs[timer].p->PRESCALER   = 4;  // Run TIMER at 1MHz
     _devs[timer].p->BITMODE     = (TIMER_BITMODE_BITMODE_32Bit << TIMER_BITMODE_BITMODE_Pos);
     _devs[timer].p->INTENSET    = (1 << (TIMER_INTENSET_COMPARE0_Pos + _devs[timer].cc_num));
+    NVIC_SetPriority(_devs[timer].irq, TIMER_IRQ_PRIORITY);
     NVIC_EnableIRQ(_devs[timer].irq);
 
     // Start the timer


### PR DESCRIPTION
This makes that no radio packets or UART bytes are lost when they arrive while a timer ISR is being performed. The timer ISR takes between 100 and 300us which is enough to loose an UART byte.
With a lower timer irq priority, the timer isr can be interrupted when an UART byte/radio packet arrives. If the IRQ priority is not set explicitly, it's 0, so has highest priority which is equal to UART's one. In this case, when an UART byte arrives while the timer ISR is being processed, the UART ISR handling is delayed until the timer ISR completes. If the ISR takes too much time, some bytes could be missed, especially with very high UART baudrates.