### PR TITLE
Ensure network id is properly handled across the codebase

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,10 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install clang-format
-        run: sudo apt install clang-format
+      - name: Install clang-format-15
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+          sudo apt-get update
+          sudo apt-get install -y clang-format-15
 
       - name: Check C/H files formatting (skip nRF)
         run: |
           find app drv mira \( -name "*.c" -o -name "*.h" \) \
-            -exec clang-format --dry-run --Werror {} +
+            -exec clang-format-15 --dry-run --Werror {} +

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     hooks:
       - id: clang-format-check
         name: Check formatting with clang-format (dry-run)
+        # note: has to use clang version 15
         entry: bash -c 'find app drv mira \( -name "*.c" -o -name "*.h" \) -exec clang-format --dry-run --Werror {} +'
         language: system
         pass_filenames: false

--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -14,6 +14,7 @@
 #include "mr_device.h"
 #include "mr_radio.h"
 #include "mr_timer_hf.h"
+#include "scheduler.h"
 #include "mira.h"
 #include "packet.h"
 
@@ -66,12 +67,13 @@ int main(void) {
 
     mira_init(MIRA_GATEWAY, MIRA_NET_ID_DEFAULT, schedule_app, &mira_event_callback);
 
+    mr_timer_hf_set_periodic_us(MIRA_APP_TIMER_DEV, 2, mr_scheduler_get_duration_us(), &mira_event_loop);
+
     while (1) {
         __SEV();
         __WFE();
         __WFE();
 
-        mira_event_loop();
     }
 }
 

--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -73,7 +73,6 @@ int main(void) {
         __SEV();
         __WFE();
         __WFE();
-
     }
 }
 

--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -65,7 +65,7 @@ int main(void) {
 
     mr_timer_hf_set_periodic_us(MIRA_APP_TIMER_DEV, 1, 1000 * 1005, &_debug_print_stats);
 
-    mira_init(MIRA_GATEWAY, MIRA_NET_ID_DEFAULT, schedule_app, &mira_event_callback);
+    mira_init(MIRA_GATEWAY, 0xBEEF, schedule_app, &mira_event_callback);
 
     mr_timer_hf_set_periodic_us(MIRA_APP_TIMER_DEV, 2, mr_scheduler_get_duration_us(), &mira_event_loop);
 

--- a/mira/association.c
+++ b/mira/association.c
@@ -344,7 +344,7 @@ void mr_assoc_gateway_clear_old_nodes(uint64_t asn) {
         }
         cell_t *cell = &schedule->cells[i];
         if (cell->assigned_node_id != 0 && asn - cell->last_received_asn > max_asn_old) {
-            mr_event_data_t event_data = (mr_event_data_t){ .data.node_info.node_id = cell->assigned_node_id, .tag = MIRA_PEER_LOST };
+            mr_event_data_t event_data = (mr_event_data_t){ .data.node_info.node_id = cell->assigned_node_id, .tag = MIRA_PEER_LOST_TIMEOUT };
             // inform the scheduler
             mr_scheduler_gateway_decrease_nodes_counter();
             // clear the cell

--- a/mira/association.c
+++ b/mira/association.c
@@ -145,7 +145,11 @@ bool mr_assoc_is_joined(void) {
 }
 
 uint16_t mr_assoc_get_network_id(void) {
-    return assoc_vars.network_id;
+    if (mira_get_node_type() == MIRA_GATEWAY) {
+        return assoc_vars.network_id;
+    } else {
+        return mr_mac_get_synced_network_id();
+    }
 }
 
 // ------------ node functions ------------

--- a/mira/association.h
+++ b/mira/association.h
@@ -48,6 +48,7 @@ bool mr_assoc_node_too_long_waiting_for_join_response(void);
 bool mr_assoc_node_too_long_synced_without_joining(void);
 void mr_assoc_node_handle_give_up_joining(void);
 void mr_assoc_node_handle_disconnect(void);
+bool mr_assoc_node_matches_network_id(uint16_t network_id);
 
 void mr_assoc_node_register_collision_backoff(void);
 void mr_assoc_node_reset_backoff(void);

--- a/mira/mac.c
+++ b/mira/mac.c
@@ -87,6 +87,7 @@ typedef struct {
     bool bg_scan_sleep_next_slot;  ///< Whether the next slot is a sleep slot
 
     uint64_t synced_gateway;  ///< ID of the gateway the node is synchronized with
+    uint16_t synced_network_id;  ///< Network ID of the gateway the node is synchronized with
     uint32_t synced_ts;       ///< Timestamp of the last synchronization
 } mac_vars_t;
 
@@ -196,6 +197,10 @@ uint64_t mr_mac_get_synced_gateway(void) {
     return mac_vars.synced_gateway;
 }
 
+uint16_t mr_mac_get_synced_network_id(void) {
+    return mac_vars.synced_network_id;
+}
+
 inline bool mr_mac_node_is_synced(void) {
     return mac_vars.synced_gateway != 0;
 }
@@ -272,6 +277,7 @@ static void new_slot_synced(void) {
 
 static void node_back_to_scanning(void) {
     mac_vars.synced_gateway = 0;
+    mac_vars.synced_network_id = 0;
     mac_vars.synced_ts      = 0;
     set_slot_state(STATE_SLEEP);
     end_slot();
@@ -643,6 +649,7 @@ static bool select_gateway_and_sync(void) {
     }
 
     mac_vars.synced_gateway = selected_gateway.beacon.src;
+    mac_vars.synced_network_id = selected_gateway.beacon.network_id;
     mac_vars.synced_ts      = now_ts;
 
     // the selected gateway may have been scanned a few slot_durations ago, so we need to account for that difference

--- a/mira/mac.c
+++ b/mira/mac.c
@@ -630,8 +630,6 @@ static bool select_gateway_and_sync(void) {
     }
 
     if (is_handover) {
-        DEBUG_GPIO_SET(&pin3);
-        DEBUG_GPIO_CLEAR(&pin3);  // pin3 DEBUG
         // a handover is going to happen, notify application about network disconnection
         mr_event_data_t event_data = { .data.gateway_info.gateway_id = mac_vars.synced_gateway, .tag = MIRA_HANDOVER };
         mac_vars.mira_event_callback(MIRA_DISCONNECTED, event_data);

--- a/mira/mac.c
+++ b/mira/mac.c
@@ -86,9 +86,9 @@ typedef struct {
     bool is_bg_scanning;           ///< Whether the node is scanning for gateways in the background
     bool bg_scan_sleep_next_slot;  ///< Whether the next slot is a sleep slot
 
-    uint64_t synced_gateway;  ///< ID of the gateway the node is synchronized with
+    uint64_t synced_gateway;     ///< ID of the gateway the node is synchronized with
     uint16_t synced_network_id;  ///< Network ID of the gateway the node is synchronized with
-    uint32_t synced_ts;       ///< Timestamp of the last synchronization
+    uint32_t synced_ts;          ///< Timestamp of the last synchronization
 } mac_vars_t;
 
 //=========================== variables ========================================
@@ -276,9 +276,9 @@ static void new_slot_synced(void) {
 }
 
 static void node_back_to_scanning(void) {
-    mac_vars.synced_gateway = 0;
+    mac_vars.synced_gateway    = 0;
     mac_vars.synced_network_id = 0;
-    mac_vars.synced_ts      = 0;
+    mac_vars.synced_ts         = 0;
     set_slot_state(STATE_SLEEP);
     end_slot();
     start_scan();
@@ -648,9 +648,9 @@ static bool select_gateway_and_sync(void) {
             &new_slot_synced);
     }
 
-    mac_vars.synced_gateway = selected_gateway.beacon.src;
+    mac_vars.synced_gateway    = selected_gateway.beacon.src;
     mac_vars.synced_network_id = selected_gateway.beacon.network_id;
-    mac_vars.synced_ts      = now_ts;
+    mac_vars.synced_ts         = now_ts;
 
     // the selected gateway may have been scanned a few slot_durations ago, so we need to account for that difference
     // NOTE: this assumes that the slot duration is the same for gateways and nodes

--- a/mira/mac.h
+++ b/mira/mac.h
@@ -80,6 +80,7 @@ extern mr_slot_durations_t slot_durations;
 void     mr_mac_init(mr_node_type_t node_type, mr_event_cb_t event_callback);
 uint64_t mr_mac_get_synced_ts(void);
 uint64_t mr_mac_get_synced_gateway(void);
+uint16_t mr_mac_get_synced_network_id(void);
 uint64_t mr_mac_get_asn(void);
 bool     mr_mac_node_is_synced(void);
 

--- a/mira/mira.c
+++ b/mira/mira.c
@@ -109,6 +109,11 @@ void mr_handle_packet(uint8_t *packet, uint8_t length) {
     }
 
     if (mira_get_node_type() == MIRA_GATEWAY) {
+        if (header->network_id != mr_assoc_get_network_id()) {
+            // ignore packets from other networks
+            return;
+        }
+
         bool from_joined_node = mr_assoc_gateway_node_is_joined(header->src);
 
         switch (header->type) {

--- a/mira/mira.c
+++ b/mira/mira.c
@@ -163,6 +163,11 @@ void mr_handle_packet(uint8_t *packet, uint8_t length) {
         }
 
     } else if (mira_get_node_type() == MIRA_NODE) {
+        if (!mr_assoc_node_matches_network_id(header->network_id)) {
+            // ignore packet with non-matching network id
+            return;
+        }
+
         bool from_my_joined_gateway = header->src == mr_mac_get_synced_gateway() && mr_assoc_get_state() == JOIN_STATE_JOINED;
 
         switch (header->type) {

--- a/mira/models.h
+++ b/mira/models.h
@@ -56,7 +56,7 @@ typedef enum {
     MIRA_NONE              = 0,
     MIRA_HANDOVER          = 1,
     MIRA_OUT_OF_SYNC       = 2,
-    MIRA_PEER_LOST         = 3,
+    MIRA_PEER_LOST         = 3,  // deprecated
     MIRA_GATEWAY_FULL      = 4,
     MIRA_PEER_LOST_TIMEOUT = 5,
     MIRA_PEER_LOST_BLOOM   = 6,

--- a/mira/packet.c
+++ b/mira/packet.c
@@ -7,7 +7,9 @@
  */
 #include <stdint.h>
 #include <string.h>
+
 #include "mr_device.h"
+#include "association.h"
 #include "packet.h"
 
 //=========================== prototypes =======================================
@@ -56,6 +58,7 @@ static size_t _set_header(uint8_t *buffer, uint64_t dst, mr_packet_type_t packet
     mr_packet_header_t header = {
         .version = MIRA_PROTOCOL_VERSION,
         .type    = packet_type,
+        .network_id = mr_assoc_get_network_id(),
         .dst     = dst,
         .src     = src,
     };

--- a/mira/packet.c
+++ b/mira/packet.c
@@ -56,11 +56,11 @@ static size_t _set_header(uint8_t *buffer, uint64_t dst, mr_packet_type_t packet
     uint64_t src = mr_device_id();
 
     mr_packet_header_t header = {
-        .version = MIRA_PROTOCOL_VERSION,
-        .type    = packet_type,
+        .version    = MIRA_PROTOCOL_VERSION,
+        .type       = packet_type,
         .network_id = mr_assoc_get_network_id(),
-        .dst     = dst,
-        .src     = src,
+        .dst        = dst,
+        .src        = src,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/mira/packet.h
+++ b/mira/packet.h
@@ -37,6 +37,7 @@ typedef enum {
 typedef struct __attribute__((packed)) {
     uint8_t          version;
     mr_packet_type_t type;
+    uint16_t         network_id;
     uint64_t         dst;
     uint64_t         src;
 } mr_packet_header_t;

--- a/mira/scheduler.c
+++ b/mira/scheduler.c
@@ -79,6 +79,10 @@ bool mr_scheduler_set_schedule(uint8_t schedule_id) {
     return false;
 }
 
+uint32_t mr_scheduler_get_duration_us(void) {
+    return MIRA_WHOLE_SLOT_DURATION * _schedule_vars.active_schedule_ptr->n_cells;
+}
+
 // ------------ node functions ------------
 
 // to be called at the NODE when processing a JOIN_RESPONSE

--- a/mira/scheduler.h
+++ b/mira/scheduler.h
@@ -50,6 +50,8 @@ mr_slot_info_t mr_scheduler_tick(uint64_t asn);
  */
 bool mr_scheduler_set_schedule(uint8_t schedule_id);
 
+uint32_t mr_scheduler_get_duration_us(void);
+
 int16_t mr_scheduler_gateway_assign_next_available_uplink_cell(uint64_t node_id, uint64_t asn);
 
 bool mr_scheduler_node_assign_myself_to_cell(uint16_t cell_index);


### PR DESCRIPTION
fixes #92 

Not having the network id in the regular packets was causing the nodes to not fix the clock drift, causing #92. 