### PR TITLE
Set MIRA_MAX_NODES to max schedule limit (101)

### DIFF
--- a/mira/mira.c
+++ b/mira/mira.c
@@ -29,10 +29,6 @@
 typedef struct {
     mr_node_type_t node_type;
     mr_event_cb_t  app_event_callback;
-
-    // gateway only
-    uint64_t joined_nodes[MIRA_MAX_NODES];
-    uint8_t  joined_nodes_len;
 } mira_vars_t;
 
 //=========================== variables ========================================

--- a/mira/mira.h
+++ b/mira/mira.h
@@ -18,7 +18,7 @@
 
 //=========================== defines ==========================================
 
-#define MIRA_MAX_NODES         10  // TODO: find a way to sync with the pre-stored schedules
+#define MIRA_MAX_NODES         101  // FIXME: find a way to sync with the pre-stored schedules
 #define MIRA_BROADCAST_ADDRESS 0xFFFFFFFFFFFFFFFF
 
 //=========================== prototypes ==========================================


### PR DESCRIPTION
fixes #91

On the one hand this is great because it is simple, but it is also so silly that the bug was that simple...

But the thing is that it was working before, with the bug on the codebase! So it was working by chance, as the memory past the buffer was being overwritten without apparent issues. Then after the codebase evolved, the error surfaced. 